### PR TITLE
libXBMC_codec.h removed and changed to libXBMC_pvr.h also fix compile fault after last request

### DIFF
--- a/pvr.octonet/addon.xml
+++ b/pvr.octonet/addon.xml
@@ -6,7 +6,7 @@
 	provider-name="digitaldevices">
 	<requires>
 		<c-pluff version="0.1" />
-		<import addon="xbmc.pvr" version="5.2.1" />
+		<import addon="xbmc.pvr" version="5.2.2" />
 	</requires>
 	<extension
 		point="xbmc.pvrclient"

--- a/src/OctonetData.cpp
+++ b/src/OctonetData.cpp
@@ -42,7 +42,7 @@ OctonetData::OctonetData()
 	lastEpgLoad = 0;
 
 	if (!loadChannelList())
-		kodi->QueueNotification(QUEUE_ERROR, kodi->GetLocalizedString(30001), channels.size());
+		libKodi->QueueNotification(QUEUE_ERROR, libKodi->GetLocalizedString(30001), channels.size());
 }
 
 OctonetData::~OctonetData(void)
@@ -68,15 +68,15 @@ int64_t OctonetData::parseID(std::string id)
 bool OctonetData::loadChannelList()
 {
 	std::string jsonContent;
-	void *f = kodi->OpenFile(("http://" + serverAddress + "/channellist.lua?select=json").c_str(), 0);
+	void *f = libKodi->OpenFile(("http://" + serverAddress + "/channellist.lua?select=json").c_str(), 0);
 	if (!f)
 		return false;
 
 	char buf[1024];
-	while (int read = kodi->ReadFile(f, buf, 1024))
+	while (int read = libKodi->ReadFile(f, buf, 1024))
 		jsonContent.append(buf, read);
 
-	kodi->CloseFile(f);
+	libKodi->CloseFile(f);
 
 	Json::Value root;
 	Json::Reader reader;
@@ -153,15 +153,15 @@ bool OctonetData::loadEPG(void)
 		return false;
 
 	std::string jsonContent;
-	void *f = kodi->OpenFile(("http://" + serverAddress + "/epg.lua?;#|encoding=gzip").c_str(), 0);
+	void *f = libKodi->OpenFile(("http://" + serverAddress + "/epg.lua?;#|encoding=gzip").c_str(), 0);
 	if (!f)
 		return false;
 
 	char buf[1024];
-	while (int read = kodi->ReadFile(f, buf, 1024))
+	while (int read = libKodi->ReadFile(f, buf, 1024))
 		jsonContent.append(buf, read);
 
-	kodi->CloseFile(f);
+	libKodi->CloseFile(f);
 
 	Json::Value root;
 	Json::Reader reader;
@@ -190,7 +190,7 @@ bool OctonetData::loadEPG(void)
 			channel = findChannel(entry.channelId);
 
 		if (channel == NULL) {
-			kodi->Log(LOG_ERROR, "EPG for unknown channel.");
+			libKodi->Log(LOG_ERROR, "EPG for unknown channel.");
 			continue;
 		}
 

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -196,13 +196,13 @@ int Socket::send ( const char* data, const unsigned int len )
 
   if (result < 0)
   {
-    kodi->Log(LOG_ERROR, "Socket::send  - select failed");
+    libKodi->Log(LOG_ERROR, "Socket::send  - select failed");
     close();
     return 0;
   }
   if (FD_ISSET(_sd, &set_w))
   {
-    kodi->Log(LOG_ERROR, "Socket::send  - failed to send data");
+    libKodi->Log(LOG_ERROR, "Socket::send  - failed to send data");
     close();
     return 0;
   }
@@ -212,7 +212,7 @@ int Socket::send ( const char* data, const unsigned int len )
   if (status == -1)
   {
     errormessage( getLastError(), "Socket::send");
-    kodi->Log(LOG_ERROR, "Socket::send  - failed to send data");
+    libKodi->Log(LOG_ERROR, "Socket::send  - failed to send data");
     close();
     return 0;
   }
@@ -296,7 +296,7 @@ bool Socket::ReadLine (string& line)
 
     if (result < 0)
     {
-      kodi->Log(LOG_DEBUG, "%s: select failed", __FUNCTION__);
+      libKodi->Log(LOG_DEBUG, "%s: select failed", __FUNCTION__);
       errormessage(getLastError(), __FUNCTION__);
       close();
       return false;
@@ -306,11 +306,11 @@ bool Socket::ReadLine (string& line)
     {
       if (retries != 0)
       {
-         kodi->Log(LOG_DEBUG, "%s: timeout waiting for response, retrying... (%i)", __FUNCTION__, retries);
+         libKodi->Log(LOG_DEBUG, "%s: timeout waiting for response, retrying... (%i)", __FUNCTION__, retries);
          retries--;
         continue;
       } else {
-         kodi->Log(LOG_DEBUG, "%s: timeout waiting for response. Aborting after 10 retries.", __FUNCTION__);
+         libKodi->Log(LOG_DEBUG, "%s: timeout waiting for response. Aborting after 10 retries.", __FUNCTION__);
          return false;
       }
     }
@@ -318,7 +318,7 @@ bool Socket::ReadLine (string& line)
     result = recv(_sd, buffer, sizeof(buffer) - 1, 0);
     if (result < 0)
     {
-      kodi->Log(LOG_DEBUG, "%s: recv failed", __FUNCTION__);
+      libKodi->Log(LOG_DEBUG, "%s: recv failed", __FUNCTION__);
       errormessage(getLastError(), __FUNCTION__);
       close();
       return false;
@@ -389,7 +389,7 @@ bool Socket::connect ( const std::string& host, const unsigned short port )
 
   if ( !setHostname( host ) )
   {
-    kodi->Log(LOG_ERROR, "Socket::setHostname(%s) failed.\n", host.c_str());
+    libKodi->Log(LOG_ERROR, "Socket::setHostname(%s) failed.\n", host.c_str());
     return false;
   }
   _port = port;
@@ -438,7 +438,7 @@ bool Socket::connect ( const std::string& host, const unsigned short port )
 
   if (address == NULL)
   {
-    kodi->Log(LOG_ERROR, "Socket::connect %s:%u\n", host.c_str(), port);
+    libKodi->Log(LOG_ERROR, "Socket::connect %s:%u\n", host.c_str(), port);
     errormessage(getLastError(), "Socket::connect");
     close();
     return false;
@@ -474,7 +474,7 @@ bool Socket::set_non_blocking ( const bool b )
 
   if (ioctlsocket(_sd, FIONBIO, &iMode) == -1)
   {
-    kodi->Log(LOG_ERROR, "Socket::set_non_blocking - Can't set socket condition to: %i", iMode);
+    libKodi->Log(LOG_ERROR, "Socket::set_non_blocking - Can't set socket condition to: %i", iMode);
     return false;
   }
 
@@ -565,7 +565,7 @@ void Socket::errormessage( int errnum, const char* functionname) const
   default:
     errmsg = "WSA Error";
   }
-  kodi->Log(LOG_ERROR, "%s: (Winsock error=%i) %s\n", functionname, errnum, errmsg);
+  libKodi->Log(LOG_ERROR, "%s: (Winsock error=%i) %s\n", functionname, errnum, errmsg);
 }
 
 int Socket::getLastError() const
@@ -623,7 +623,7 @@ bool Socket::set_non_blocking ( const bool b )
 
   if(fcntl (_sd , F_SETFL, opts) == -1)
   {
-    kodi->Log(LOG_ERROR, "Socket::set_non_blocking - Can't set socket flags to: %i", opts);
+    libKodi->Log(LOG_ERROR, "Socket::set_non_blocking - Can't set socket flags to: %i", opts);
     return false;
   }
   return true;
@@ -699,7 +699,7 @@ void Socket::errormessage( int errnum, const char* functionname) const
       break;
   }
 
-  kodi->Log(LOG_ERROR, "%s: (errno=%i) %s\n", functionname, errnum, errmsg);
+  libKodi->Log(LOG_ERROR, "%s: (errno=%i) %s\n", functionname, errnum, errmsg);
 }
 
 int Socket::getLastError() const

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -36,7 +36,7 @@ std::string octonetAddress = "";
 
 /* internal state variables */
 ADDON_STATUS addonStatus = ADDON_STATUS_UNKNOWN;
-CHelper_libXBMC_addon *kodi = NULL;
+CHelper_libXBMC_addon *libKodi = NULL;
 CHelper_libXBMC_pvr *pvr = NULL;
 
 OctonetData *data = NULL;
@@ -49,7 +49,7 @@ extern "C" {
 void ADDON_ReadSettings(void)
 {
 	char buffer[2048];
-	if (kodi->GetSetting("octonetAddress", &buffer))
+	if (libKodi->GetSetting("octonetAddress", &buffer))
 		octonetAddress = buffer;
 }
 
@@ -59,22 +59,22 @@ ADDON_STATUS ADDON_Create(void *callbacks, void* props)
 		return ADDON_STATUS_UNKNOWN;
 
 	PVR_PROPERTIES *pvrprops = (PVR_PROPERTIES*)props;
-	kodi = new CHelper_libXBMC_addon;
-	if (!kodi->RegisterMe(callbacks)) {
-		kodi->Log(LOG_ERROR, "%s: Failed to register octonet addon", __func__);
-		SAFE_DELETE(kodi);
+	libKodi = new CHelper_libXBMC_addon;
+	if (!libKodi->RegisterMe(callbacks)) {
+		libKodi->Log(LOG_ERROR, "%s: Failed to register octonet addon", __func__);
+		SAFE_DELETE(libKodi);
 		return ADDON_STATUS_PERMANENT_FAILURE;
 	}
 
 	pvr = new CHelper_libXBMC_pvr;
 	if (!pvr->RegisterMe(callbacks)) {
-		kodi->Log(LOG_ERROR, "%s: Failed to register octonet pvr addon", __func__);
+		libKodi->Log(LOG_ERROR, "%s: Failed to register octonet pvr addon", __func__);
 		SAFE_DELETE(pvr);
-		SAFE_DELETE(kodi);
+		SAFE_DELETE(libKodi);
 		return ADDON_STATUS_PERMANENT_FAILURE;
 	}
 
-	kodi->Log(LOG_DEBUG, "%s: Creating octonet pvr addon", __func__);
+	libKodi->Log(LOG_DEBUG, "%s: Creating octonet pvr addon", __func__);
 	ADDON_ReadSettings();
 
 	data = new OctonetData;
@@ -88,7 +88,7 @@ void ADDON_Stop() {} /* no-op */
 void ADDON_Destroy()
 {
 	delete pvr;
-	delete kodi;
+	delete libKodi;
 	addonStatus = ADDON_STATUS_UNKNOWN;
 }
 
@@ -174,12 +174,12 @@ PVR_ERROR GetDriveSpace(long long* iTotal, long long* iUsed) { return PVR_ERROR_
 PVR_ERROR CallMenuHook(const PVR_MENUHOOK& menuhook, const PVR_MENUHOOK_DATA &item) { return PVR_ERROR_NOT_IMPLEMENTED; }
 
 void OnSystemSleep() {
-	kodi->Log(LOG_INFO, "Received event: %s", __FUNCTION__);
+	libKodi->Log(LOG_INFO, "Received event: %s", __FUNCTION__);
 	// FIXME: Disconnect?
 }
 
 void OnSystemWake() {
-	kodi->Log(LOG_INFO, "Received event: %s", __FUNCTION__);
+	libKodi->Log(LOG_INFO, "Received event: %s", __FUNCTION__);
 	// FIXME:Reconnect?
 }
 

--- a/src/client.h
+++ b/src/client.h
@@ -28,7 +28,7 @@
 #define __func__ __FUNCTION__
 #endif
 
-extern ADDON::CHelper_libXBMC_addon *kodi;
+extern ADDON::CHelper_libXBMC_addon *libKodi;
 extern CHelper_libXBMC_pvr *pvr;
 
 /* IP or hostname of the octonet to be connected to */

--- a/src/rtsp_client.cpp
+++ b/src/rtsp_client.cpp
@@ -309,13 +309,13 @@ bool rtsp_open(const string& name, const string& url_str)
 	rtsp->level = 0;
 	rtsp->quality = 0;
 
-	kodi->Log(LOG_DEBUG, "try to open '%s'", url_str.c_str());
+	libKodi->Log(LOG_DEBUG, "try to open '%s'", url_str.c_str());
 
 	url dst = parse_url(url_str);
-	kodi->Log(LOG_DEBUG, "connect to host '%s'", dst.host.c_str());
+	libKodi->Log(LOG_DEBUG, "connect to host '%s'", dst.host.c_str());
 
 	if(!rtsp->tcp_sock.connect(dst.host, dst.port)) {
-		kodi->Log(LOG_ERROR, "Failed to connect to RTSP server %s:%d", dst.host.c_str(), dst.port);
+		libKodi->Log(LOG_ERROR, "Failed to connect to RTSP server %s:%d", dst.host.c_str(), dst.port);
 		goto error;
 	}
 
@@ -353,7 +353,7 @@ bool rtsp_open(const string& name, const string& url_str)
 	rtsp->tcp_sock.send(setup_ss.str());
 
 	if (rtsp_handle() != RTSP_RESULT_OK) {
-		kodi->Log(LOG_ERROR, "Failed to setup RTSP session");
+		libKodi->Log(LOG_ERROR, "Failed to setup RTSP session");
 		goto error;
 	}
 
@@ -368,7 +368,7 @@ bool rtsp_open(const string& name, const string& url_str)
 	rtsp->tcp_sock.send(play_ss.str());
 
 	if (rtsp_handle() != RTSP_RESULT_OK) {
-		kodi->Log(LOG_ERROR, "Failed to play RTSP session");
+		libKodi->Log(LOG_ERROR, "Failed to play RTSP session");
 		goto error;
 	}
 
@@ -453,7 +453,7 @@ static void rtsp_teardown() {
 		rtsp->tcp_sock.send(ss.str());
 
 		if (rtsp_handle() != RTSP_RESULT_OK) {
-			kodi->Log(LOG_ERROR, "Failed to teardown RTSP session");
+			libKodi->Log(LOG_ERROR, "Failed to teardown RTSP session");
 			return;
 		}
 	}


### PR DESCRIPTION
Related to Kodi Pull Request xbmc/xbmc#12028 where libXBMC_codec.h becomes removed.

Was also a compile fault with request before where namespace `kodi` becomes added who conflicts the `kodi` pointer of `libXBMC_addon.h`. The add of this lib pointers is after the final rework no more needed (coming on next changes).