### PR TITLE
[Testing Required] update jsoncpp 0.10.6

### DIFF
--- a/depends/common/jsoncpp/jsoncpp.txt
+++ b/depends/common/jsoncpp/jsoncpp.txt
@@ -1,1 +1,1 @@
-jsoncpp http://mirrors.kodi.tv/build-deps/sources/jsoncpp-src-0.5.0.tar.gz
+jsoncpp https://github.com/open-source-parsers/jsoncpp/archive/0.10.6.tar.gz


### PR DESCRIPTION
Hi,

as part of an attempt to update some dependencies on a few of Kodi's pvr addons, this is a PR to update to the latest jsoncpp branch that is feature compatible with the 0.5.0 version used in several pvr addons.

I dont have the backend for testing, however i have done the same version bump on pvr.hdhomerun with no apparent regressions. Ive requested MilHouse to add this PR into his nightly builds to get some testing done via there, but if any other users can actively test and let me know if there are any regressions they notice.

Below is the discussion over at LibreElec
https://github.com/LibreELEC/LibreELEC.tv/pull/2138
