### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,10 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(JsonCpp REQUIRED)
 
 include_directories(
-	${kodiplatform_INCLUDE_DIRS}
 	${p8-platform_INCLUDE_DIRS}
 	${KODI_INCLUDE_DIR}
 	${JSONCPP_INCLUDE_DIRS})

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-octonet
 Priority: extra
 Maintainer: Julian Scheel <julian@jusst.de>
 Build-Depends: debhelper (>= 9.0.0), cmake, libjsoncpp-dev,
-               libkodiplatform-dev (>= 16.0.0), kodi-addon-dev
+               libp8-platform-dev, kodi-addon-dev
 Standards-Version: 3.9.4
 Section: libs
 Homepage: https://github.com/DigitalDevices/pvr.octonet


### PR DESCRIPTION
The pvr.octonet binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.