### PR TITLE
[pvr.octonet] 1.1.0

### DIFF
--- a/pvr.octonet/addon.xml.in
+++ b/pvr.octonet/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
 	id="pvr.octonet"
-	version="1.0.0"
+	version="1.1.0"
 	name="Digital Devices Octopus NET Client"
 	provider-name="digitaldevices">
 	<requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Due to https://github.com/xbmc/xbmc/pull/16444 and GUI API breakage, a version bump is required

(only merge once the mentioned PR is merged)