### PR TITLE
Fix windows build

### DIFF
--- a/pvr.octonet/addon.xml.in
+++ b/pvr.octonet/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
 	id="pvr.octonet"
-	version="4.0.0"
+	version="4.0.1"
 	name="Digital Devices Octopus NET Client"
 	provider-name="digitaldevices">
 	<requires>@ADDON_DEPENDS@</requires>

--- a/src/OctonetData.cpp
+++ b/src/OctonetData.cpp
@@ -18,7 +18,7 @@
 #include <sstream>
 #include <string>
 
-#ifdef __WINDOWS__
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
 #define timegm _mkgmtime
 #endif
 


### PR DESCRIPTION
Fixes windows build error:

C:\Users\Kodi\Kodi\jenkins\builds\workspace\binary-addons\kodi-windows-x86_64-Matrix\tools\depends\target\binary-addons\pvr.octonet\src\OctonetData.cpp(198): error C3861: 'timegm': identifier not found